### PR TITLE
Route53 destroy

### DIFF
--- a/terraform/aws/cluster/main.tf
+++ b/terraform/aws/cluster/main.tf
@@ -1,7 +1,10 @@
 resource "kops_cluster" "cluster" {
   name               = var.cluster_name
-  cloud_provider     = "aws"
   kubernetes_version = var.kubernetes_version
+
+  cloud_provider {
+    aws {}
+  }
 
   # User sometime have diff TLD in their cluster name
   # If not given, use the subdomain

--- a/terraform/aws/vpc/route53.tf
+++ b/terraform/aws/vpc/route53.tf
@@ -3,8 +3,9 @@ data "aws_route53_zone" "parent_zone" {
 }
 
 resource "aws_route53_zone" "zone" {
-  name    = var.subdomain
-  comment = "Created on behalf of the ${var.cluster_name} Kubernetes cluster"
+  name          = var.subdomain
+  force_destroy = true
+  comment       = "Created on behalf of the ${var.cluster_name} Kubernetes cluster"
 }
 
 resource "aws_route53_record" "subzone-ns-records" {

--- a/terragrunt/kops/cluster/terragrunt.hcl
+++ b/terragrunt/kops/cluster/terragrunt.hcl
@@ -19,7 +19,7 @@ terraform {
     }
     kops = {
       source = "eddycharly/kops"
-      version = "1.23.5"
+      version = "1.25.3"
     }
   }
 


### PR DESCRIPTION
Without this, terragrunt will fail when destroying a cluster, if external-dns has added records to the cluster dns zone.