### PR TITLE
terragrunt/kops: Enable the configuration of subnets for custom ig's

### DIFF
--- a/terraform/aws/cluster/variables.tf
+++ b/terraform/aws/cluster/variables.tf
@@ -11,6 +11,7 @@ variable "instance_groups" {
       taints            = optional(list(string))
       max_price         = optional(string)
       zones             = optional(list(string))
+      subnets           = optional(list(string), [ "0", "1", "2" ])
     })
   )
   description = "Instance Group"


### PR DESCRIPTION
With this PR, it is now possible to configure which subnet aka. availability zone, a custom instance group is using